### PR TITLE
Java 9

### DIFF
--- a/joinfaces-autoconfigure/pom.xml
+++ b/joinfaces-autoconfigure/pom.xml
@@ -222,6 +222,21 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <optional>true</optional>

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initializer/JsfClassFactory.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initializer/JsfClassFactory.java
@@ -126,9 +126,11 @@ public class JsfClassFactory {
 			}
 
 			// add project classes folder
-			Collection<URL> urls = ClasspathHelper.forJavaClassPath().size() > ClasspathHelper.forManifest().size()
-					? ClasspathHelper.forJavaClassPath() : ClasspathHelper.forManifest();
-			for (URL url : urls) {
+			Collection<URL> urlsClassesFolder = new ArrayList<>();
+			Collection<String> stringsClassesFolder = new HashSet<>();
+			add(urlsClassesFolder, stringsClassesFolder, ClasspathHelper.forJavaClassPath());
+			add(urlsClassesFolder, stringsClassesFolder, ClasspathHelper.forManifest());
+			for (URL url : urlsClassesFolder) {
 				String file = url.getFile();
 				// check if adding classes folder
 				if (isClassesFolder(file)) {

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initializer/JsfClassFactory.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initializer/JsfClassFactory.java
@@ -126,7 +126,9 @@ public class JsfClassFactory {
 			}
 
 			// add project classes folder
-			for (URL url : ClasspathHelper.forManifest()) {
+			Collection<URL> urls = ClasspathHelper.forJavaClassPath().size() > ClasspathHelper.forManifest().size()
+					? ClasspathHelper.forJavaClassPath() : ClasspathHelper.forManifest();
+			for (URL url : urls) {
 				String file = url.getFile();
 				// check if adding classes folder
 				if (isClassesFolder(file)) {

--- a/joinfaces-dependencies/pom.xml
+++ b/joinfaces-dependencies/pom.xml
@@ -48,6 +48,9 @@
         <rewrite.version>3.4.2.Final</rewrite.version>
         
         <findbugs-annotations.version>3.0.1u2</findbugs-annotations.version>
+        
+        <activation.version>1.1.1</activation.version>
+        <jaxb.version>2.3.0</jaxb.version>
 
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
@@ -290,6 +293,25 @@
                 <groupId>org.ocpsoft.rewrite</groupId>
                 <artifactId>rewrite-integration-cdi</artifactId>
                 <version>${rewrite.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${activation.version}</version>
+                <scope>runtime</scope>
             </dependency>
 
             <dependency>

--- a/test-projects/pom.xml
+++ b/test-projects/pom.xml
@@ -20,6 +20,8 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- adding required dependencies by richfaces not present in java 9
- target minimum java 8 to test-project
- fix reflections method usage to search url class folder

This PR lets joinfaces building with java 8 and 9. examples works ok too.